### PR TITLE
Add stopPropagation to _start function.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -108,6 +108,7 @@ IScroll.prototype = {
 				return;
 			}
 		}
+		e.stopPropagation();
 
 		if ( !this.enabled || (this.initiated && utils.eventType[e.type] !== this.initiated) ) {
 			return;


### PR DESCRIPTION
Allows for nested iscrolls.
